### PR TITLE
refactor: 💡 Rename swagger by openapi/specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,9 @@ restui {
 
     // Labels name use to detect RestUI compatible container
     labels {
-      port  = "restui.swagger.endpoint.port" // Label specifying the port on which the OpenApi spec is available.
-      service-name = "restui.swagger.endpoint.service-name" // Label specifying the service name for RestUI.
-      swagger-path = "restui.swagger.endpoint.swagger-path" // Label of the path where the OpenApi spec file is.
+      port  = "restui.specification.endpoint.port" // Label specifying the port on which the OpenApi spec is available.
+      service-name = "restui.specification.endpoint.service-name" // Label specifying the service name for RestUI.
+      specification-path = "restui.specification.endpoint.specification-path" // Label of the path where the OpenApi spec file is.
     }
 
   }
@@ -122,9 +122,9 @@ restui {
     polling-interval = "1 minute" // Interval between each polling
 
     labels {
-      port  = "restui.swagger.endpoint.port" // Label specifying the port on which the OpenApi spec is available.
-      protocol = "restui.swagger.endpoint.protocol" // Label specifying which protocol the OpenApi spec is exposed.
-      swagger-path = "restui.swagger.endpoint.swagger-path" // Label of the path where the OpenApi spec file is.
+      port  = "restui.specification.endpoint.port" // Label specifying the port on which the OpenApi spec is available.
+      protocol = "restui.specification.endpoint.protocol" // Label specifying which protocol the OpenApi spec is exposed.
+      specification-path = "restui.specification.endpoint.specification-path" // Label of the path where the OpenApi spec file is.
     }
   }
 
@@ -157,20 +157,20 @@ The docker provider list all running containers and detect new and stopped conta
 
 To find a compatible container, those containers **MUST** have the following labels on it:
 
-- A label for the port where the OpenApi spec lays (default to: *restui.swagger.endpoint.port*)
-- A label giving the service's name (default to: *restui.swagger.endpoint.service-name*)
+- A label for the port where the OpenApi spec lays (default to: *restui.specification.endpoint.port*)
+- A label giving the service's name (default to: *restui.specification.endpoint.service-name*)
 
 The following labels are optional:
 
-- A label specifying the path where the OpenApi spec lays (default to: *restui.swagger.endpoint.swagger-path*).
-  If this label is not provided with the default path is: **/swagger.yaml**
+- A label specifying the path where the OpenApi spec lays (default to: *restui.specification.endpoint.specification-path*).
+  If this label is not provided with the default path is: **/specification.yaml**
 
 ------------------------------------------------------------------------------------------------
 
 Example:
 
 ```sh
-docker  run --rm -l "restui.swagger.endpoint.port=80" -l "restui.swagger.endpoint.service-name=nginx" -v $(pwd):/usr/share/nginx/html:ro nginx:alpine
+docker  run --rm -l "restui.specification.endpoint.port=80" -l "restui.specification.endpoint.service-name=nginx" -v $(pwd):/usr/share/nginx/html:ro nginx:alpine
 ```
 
 ------------------------------------------------------------------------------------------------
@@ -187,13 +187,13 @@ The value for the interval is defined by `polling-interval` which default to `1 
 
 To find compatible services, those services **MUST** have the following labels on it:
 
-- A label for the port where the OpenApi spec lays (default to: *restui.swagger.endpoint.port*)
-- A label specifying the protocol to use (default to: *restui.swagger.endpoint.protocol*)
+- A label for the port where the OpenApi spec lays (default to: *restui.specification.endpoint.port*)
+- A label specifying the protocol to use (default to: *restui.specification.endpoint.protocol*)
 
 The following labels are optional:
 
-- A label specifying the path where the OpenApi spec lays (default to: *restui.swagger.endpoint.swagger-path*).
-  If this label is not provided with the default path is: **/swagger.yaml**
+- A label specifying the path where the OpenApi spec lays (default to: *restui.specification.endpoint.specification-path*).
+  If this label is not provided with the default path is: **/specification.yaml**
 
 Also those services **MUST** have a `ClusterIP` (the provider will infer the address from the `ClusterIP`)
 
@@ -206,9 +206,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    restui.swagger.endpoint.port: "80"
-    restui.swagger.endpoint.protocol: http
-  name: swagger
+    restui.specification.endpoint.port: "80"
+    restui.specification.endpoint.protocol: http
+  name: specification
   namespace: default
 spec:
   clusterIP: 10.96.0.2
@@ -229,7 +229,7 @@ kind: Deployment
 metadata:
   labels:
     selector: deployment
-  name: swagger
+  name: openapi
   namespace: default
 spec:
   progressDeadlineSeconds: 600
@@ -251,7 +251,7 @@ spec:
       containers:
       - image: nginx:alpine
         imagePullPolicy: Always
-        name: swagger5
+        name: openapi
         ports:
         - containerPort: 80
           name: 80tcp02
@@ -293,7 +293,7 @@ The object follows this schema:
   location = "" // Full url, `organization/project` for Github or
                 // a regex (the string **MUST** starts and ends with `/`)
   branch = "" // Branch to clone (default to `master` or inferred from the default branch in Github)
-  swagger-paths = [] // List of OpenApi spec files or directories containing those kind of files
+  specification-paths = [] // List of OpenApi spec files or directories containing those kind of files
                      // inside your repository. Those paths are overrided by the restui configuration file inside
                      // of your repository.
 }
@@ -308,7 +308,7 @@ YAML
 # Example: "https://github.com/MyOrg/MyRepo" -> "MyOrg/MyOrg"
 name = "service name"
 # List of OpenApi spec files or directories
-swagger = []
+specifications = []
 ```
 
 If you intend to use the Github option you need to provide a token.

--- a/providers/docker/src/main/resources/reference.conf
+++ b/providers/docker/src/main/resources/reference.conf
@@ -3,9 +3,9 @@ restui {
   provider.docker {
     host =  "unix:///var/run/docker.sock"
     labels {
-      port  = "restui.swagger.endpoint.port"
-      service-name = "restui.swagger.endpoint.service-name"
-      swagger-path = "restui.swagger.endpoint.swagger-path"
+      port  = "restui.specification.endpoint.port"
+      service-name = "restui.specification.endpoint.service-name"
+      specification-path = "restui.specification.endpoint.specification-path"
     }
   }
 }

--- a/providers/docker/src/main/scala/restui/providers/docker/DockerClient.scala
+++ b/providers/docker/src/main/scala/restui/providers/docker/DockerClient.scala
@@ -100,7 +100,7 @@ class DockerClient(private val client: JDockerClient, private val settings: Sett
     for {
       labels    <- findMatchingLabels(labels)
       ipAddress <- findFirstIpAddress(networks)
-    } yield (labels.serviceName, s"http://$ipAddress:${labels.port.toInt}${labels.swaggerPath}")
+    } yield (labels.serviceName, s"http://$ipAddress:${labels.port.toInt}${labels.specificationPath}")
 
   private def findFirstIpAddress(networks: mutable.Map[String, ContainerNetwork]): Option[String] =
     networks.toList.headOption.map(_._2.getIpAddress)
@@ -109,8 +109,8 @@ class DockerClient(private val client: JDockerClient, private val settings: Sett
     for {
       serviceName <- labels.get(settings.labels.serviceName)
       port        <- labels.get(settings.labels.port)
-      swaggerPath = labels.getOrElse(settings.labels.swaggerPath, "/swagger.yaml")
-    } yield Labels(serviceName, port, swaggerPath)
+      specificationPath = labels.getOrElse(settings.labels.specificationPath, "/specification.yaml")
+    } yield Labels(serviceName, port, specificationPath)
 }
 
 object DockerClient {

--- a/providers/docker/src/main/scala/restui/providers/docker/Settings.scala
+++ b/providers/docker/src/main/scala/restui/providers/docker/Settings.scala
@@ -3,15 +3,15 @@ package restui.providers.docker
 import com.typesafe.config.Config
 
 final case class Settings(dockerHost: String, labels: Labels)
-final case class Labels(serviceName: String, port: String, swaggerPath: String)
+final case class Labels(serviceName: String, port: String, specificationPath: String)
 
 object Settings {
   private val Namespace = "restui.provider.docker"
   def from(config: Config): Settings = {
-    val dockerHost  = config.getString(s"$Namespace.host")
-    val serviceName = config.getString(s"$Namespace.labels.service-name")
-    val port        = config.getString(s"$Namespace.labels.port")
-    val swaggerPath = config.getString(s"$Namespace.labels.swagger-path")
-    Settings(dockerHost, Labels(serviceName, port, swaggerPath))
+    val dockerHost        = config.getString(s"$Namespace.host")
+    val serviceName       = config.getString(s"$Namespace.labels.service-name")
+    val port              = config.getString(s"$Namespace.labels.port")
+    val specificationPath = config.getString(s"$Namespace.labels.specification-path")
+    Settings(dockerHost, Labels(serviceName, port, specificationPath))
   }
 }

--- a/providers/docker/src/test/scala/restui/providers/docker/DockerClientSpec.scala
+++ b/providers/docker/src/test/scala/restui/providers/docker/DockerClientSpec.scala
@@ -34,8 +34,8 @@ class DockerClientSpec
   override def afterAll: Unit =
     TestKit.shutdownActorSystem(system)
 
-  private val settings                   = Settings("myDocker.sock", Labels("name", "port", "swagger"))
-  private val MatchingContainerLabels    = Map("name" -> ServiceName, "port" -> "9999", "swagger" -> "/openapi.yaml").asJava
+  private val settings                   = Settings("myDocker.sock", Labels("name", "port", "specification"))
+  private val MatchingContainerLabels    = Map("name" -> ServiceName, "port" -> "9999", "specification" -> "/openapi.yaml").asJava
   private val NonMatchingContainerLabels = Map("name" -> ServiceName).asJava
 
   "Listing endpoints" when {

--- a/providers/git/src/main/scala/restui/providers/git/git/data/package.scala
+++ b/providers/git/src/main/scala/restui/providers/git/git/data/package.scala
@@ -5,8 +5,8 @@ import java.io.File
 package object data {
   final case class Repository(uri: String,
                               branch: String,
-                              swaggerPaths: List[String],
+                              specificationPaths: List[String],
                               directory: Option[File] = None,
                               serviceName: Option[String] = None)
-  final case class RestUI(name: Option[String], swaggers: List[String])
+  final case class RestUI(name: Option[String], specifications: List[String])
 }

--- a/providers/git/src/main/scala/restui/providers/git/github/Github.scala
+++ b/providers/git/src/main/scala/restui/providers/git/github/Github.scala
@@ -25,16 +25,16 @@ object Github extends LazyLogging {
     AkkaFlow[GithubClient].flatMapConcat { client =>
       GithubClient
         .listRepositories(client)
-        .map(repos => client.settings -> repos)
+        .map(repositories => client.settings -> repositories)
     }.map {
-      case (GithubSettings(token, _, _, repos), Node(name, url, branch)) =>
-        repos
+      case (GithubSettings(token, _, _, repositories), Node(name, url, branch)) =>
+        repositories
           .find(_.location.isMatching(name))
-          .map { repo =>
-            logger.debug(s"Matching repo: $name")
+          .map { repository =>
+            logger.debug(s"Matching repository: $name")
             val uri          = Uri(url)
             val uriWithToken = uri.withAuthority(uri.authority.copy(userinfo = token))
-            Repository(uriWithToken.toString, branch, repo.swaggerPaths)
+            Repository(uriWithToken.toString, branch, repository.specificationPaths)
           }
-    }.collect { case Some(repo) => repo }
+    }.collect { case Some(repository) => repository }
 }

--- a/providers/git/src/main/scala/restui/providers/git/settings/RepositorySettings.scala
+++ b/providers/git/src/main/scala/restui/providers/git/settings/RepositorySettings.scala
@@ -6,7 +6,7 @@ import scala.jdk.CollectionConverters._
 
 import com.typesafe.config.{Config, ConfigFactory}
 
-final case class RepositorySettings(location: Location, branch: Option[String] = None, swaggerPaths: List[String] = Nil)
+final case class RepositorySettings(location: Location, branch: Option[String] = None, specificationPaths: List[String] = Nil)
 
 object RepositorySettings {
 
@@ -23,10 +23,10 @@ object RepositorySettings {
     val branch =
       if (config.hasPath("branch")) Some(config.getString("branch"))
       else None
-    val swaggerPaths =
-      if (config.hasPath("swagger-paths")) config.getStringList("swagger-paths").asScala.toList
+    val specificationPaths =
+      if (config.hasPath("specification-paths")) config.getStringList("specification-paths").asScala.toList
       else Nil
-    RepositorySettings(location, branch, swaggerPaths)
+    RepositorySettings(location, branch, specificationPaths)
   }
 }
 sealed trait Location {

--- a/providers/git/src/test/scala/restui/providers/git/SettingsSpec.scala
+++ b/providers/git/src/test/scala/restui/providers/git/SettingsSpec.scala
@@ -56,7 +56,7 @@ class SettingsSpec extends AnyWordSpec with Matchers {
 |     repositories = [
 |       {
 |         location = "myOrg/Test"
-|         swagger-paths = ["test/"]
+|         specification-paths = ["test/"]
 |       },
 |       {
 |         location = "/myOrg\/.+/"
@@ -81,36 +81,6 @@ class SettingsSpec extends AnyWordSpec with Matchers {
           )
         )
       }
-    }
-
-    "load git" in {
-      val config = loadConfig("""restui.provider.git {
-|  cache-duration =  "2 hours"
-|  vcs {
-|    git {
-|     repositories = [
-|       {
-|         location = "myOrg/Test"
-|         swagger-paths = ["test/"]
-|       },
-|       {
-|         location = "/myOrg\/.+/"
-|       },
-|       "restui"
-|     ]
-|    }
-|  }
-|}""".stripMargin)
-      Settings.from(config) shouldBe Settings(
-        2.hours,
-        List(
-          GitSettings(
-            RepositorySettings(Location.Uri("myOrg/Test"), None, List("test/")) :: RepositorySettings(
-              Location.Regex("myOrg/.+"),
-              None,
-              Nil) :: RepositorySettings(Location.Uri("restui"), None, Nil) :: Nil)
-        )
-      )
     }
   }
 

--- a/providers/git/src/test/scala/restui/providers/git/github/GithubSpec.scala
+++ b/providers/git/src/test/scala/restui/providers/git/github/GithubSpec.scala
@@ -38,10 +38,10 @@ class GithubSpec extends TestBase with Inside with Inspectors {
 
     forAll(results) { result =>
       inside(result) {
-        case GitRepository(uri, branch, _, swagger, ref) =>
+        case GitRepository(uri, branch, _, specification, ref) =>
           uri shouldBe "https://MyAwesomeUser@github.com/MyAwesomeUser/MyAwesomeRepo"
           branch shouldBe "master"
-          swagger shouldBe empty
+          specification shouldBe empty
           ref should not be Symbol("defined")
       }
     }

--- a/providers/kubernetes/src/main/resources/reference.conf
+++ b/providers/kubernetes/src/main/resources/reference.conf
@@ -3,9 +3,9 @@ restui {
   provider.kubernetes {
     polling-interval = "1 minute"
     labels {
-      port  = "restui.swagger.endpoint.port"
-      protocol = "restui.swagger.endpoint.protocol"
-      swagger-path = "restui.swagger.endpoint.swagger-path"
+      port  = "restui.specification.endpoint.port"
+      protocol = "restui.specification.endpoint.protocol"
+      specification-path = "restui.specification.endpoint.specification-path"
     }
   }
 }

--- a/providers/kubernetes/src/main/scala/restui/providers/kubernetes/Settings.scala
+++ b/providers/kubernetes/src/main/scala/restui/providers/kubernetes/Settings.scala
@@ -6,15 +6,15 @@ import scala.jdk.DurationConverters._
 import com.typesafe.config.Config
 
 final case class Settings(pollingInterval: FiniteDuration, labels: Labels)
-final case class Labels(protocol: String, port: String, swaggerPath: String)
+final case class Labels(protocol: String, port: String, specificationPath: String)
 
 object Settings {
   private val Namespace = "restui.provider.kubernetes"
   def from(config: Config): Settings = {
-    val pollingInterval = config.getDuration(s"$Namespace.polling-interval")
-    val port            = config.getString(s"$Namespace.labels.port")
-    val swaggerPath     = config.getString(s"$Namespace.labels.swagger-path")
-    val protocol        = config.getString(s"$Namespace.labels.protocol")
-    Settings(pollingInterval.toScala, Labels(protocol, port, swaggerPath))
+    val pollingInterval   = config.getDuration(s"$Namespace.polling-interval")
+    val port              = config.getString(s"$Namespace.labels.port")
+    val specificationPath = config.getString(s"$Namespace.labels.specification-path")
+    val protocol          = config.getString(s"$Namespace.labels.protocol")
+    Settings(pollingInterval.toScala, Labels(protocol, port, specificationPath))
   }
 }

--- a/rest-ui/version.sbt
+++ b/rest-ui/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.3.1-SNAPSHOT"
+version in ThisBuild := "0.4.0-SNAPSHOT"


### PR DESCRIPTION
OpenApi is the current name for Swagger/OpenApi spec

BREAKING CHANGE: 🧨 Default configuration of labels for Docker and K8S
Configuration for git and restui config file

✅ Close: #26