### PR TITLE
refactor: 💡 Allow git cache, avoid cloning every time

### DIFF
--- a/providers/git/src/main/scala/restui/providers/git/github/Github.scala
+++ b/providers/git/src/main/scala/restui/providers/git/github/Github.scala
@@ -1,40 +1,61 @@
 package restui.providers.git.github
 
 import scala.concurrent.ExecutionContext
-import scala.concurrent.duration._
 
-import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.Uri
-import akka.stream.scaladsl.{Flow => AkkaFlow, Source => AkkaSource}
+import akka.stream.SourceShape
+import akka.stream.scaladsl.{Broadcast, Flow => AkkaFlow, GraphDSL, Merge, Source => AkkaSource}
 import com.typesafe.scalalogging.LazyLogging
+import restui.Concurrency
+import restui.providers.git.Source
 import restui.providers.git.git.data.Repository
 import restui.providers.git.github.data.Node
-import restui.providers.git.settings.GithubSettings
-import restui.providers.git.{Flow, Source}
 
 object Github extends LazyLogging {
-  def retrieveRepositoriesRegularly(
-      githubClient: GithubClient)(implicit system: ActorSystem, executionContext: ExecutionContext): Source[Repository] =
-    AkkaSource
-      .tick(0.seconds, githubClient.settings.pollingInterval, githubClient)
-      .via(retrieveRepositories.async)
-      .mapMaterializedValue(_ => NotUsed)
+  def apply(githubClient: GithubClient)(implicit system: ActorSystem, executionContext: ExecutionContext): Source[Repository] =
+    AkkaSource.fromGraph(GraphDSL.create() { implicit builder =>
+      import GraphDSL.Implicits._
+      val init = builder.add(AkkaSource.single(List.empty[String]))
 
-  private def retrieveRepositories(implicit system: ActorSystem, executionContext: ExecutionContext): Flow[GithubClient, Repository] =
-    AkkaFlow[GithubClient].flatMapConcat { client =>
-      GithubClient
-        .listRepositories(client)
-        .map(repositories => client.settings -> repositories)
-    }.map {
-      case (GithubSettings(token, _, _, repositories), Node(name, url, branch)) =>
-        repositories
-          .find(_.location.isMatching(name))
-          .map { repository =>
-            logger.debug(s"Matching repository: $name")
-            val uri          = Uri(url)
-            val uriWithToken = uri.withAuthority(uri.authority.copy(userinfo = token))
-            Repository(uriWithToken.toString, branch, repository.specificationPaths)
+      val outbound = builder.add(
+        AkkaFlow[(List[String], List[Node])].flatMapMerge(
+          Concurrency.AvailableCore,
+          {
+            case (oldRepositories, newRepositories) =>
+              val repositories = newRepositories.collect {
+                case Node(name, url, branch) if !oldRepositories.contains(name) =>
+                  githubClient.settings.repos.find(_.location.isMatching(name)).map { repository =>
+                    logger.debug(s"Matching repository: $name")
+                    val uri          = Uri(url)
+                    val uriWithToken = uri.withAuthority(uri.authority.copy(userinfo = githubClient.settings.apiToken))
+                    Repository(uriWithToken.toString, branch, repository.specificationPaths)
+                  }
+
+              }.collect { case Some(repository) => repository }
+              AkkaSource(repositories)
           }
-    }.collect { case Some(repository) => repository }
+        ))
+
+      val retrieveRepositories = builder.add(AkkaFlow[List[String]].flatMapConcat { old =>
+        GithubClient
+          .listRepositories(githubClient)
+          .fold(List.empty[Node])(_ :+ _)
+          .map(repositories => old -> repositories)
+          .async
+      })
+
+      val merge = builder.add(Merge[List[String]](2))
+
+      val delay = builder.add(AkkaFlow[(List[String], List[Node])].delay(githubClient.settings.pollingInterval).map {
+        case (_, repositories) => repositories.map(_.name)
+      })
+
+      val broadcast = builder.add(Broadcast[(List[String], List[Node])](2, eagerCancel = true))
+      // format: OFF
+      init ~> merge ~> retrieveRepositories ~> broadcast ~> outbound
+              merge <~ delay <~ broadcast
+      // format: ON
+      SourceShape(outbound.out)
+    })
 }

--- a/providers/git/src/main/scala/restui/providers/git/vcs/VCS.scala
+++ b/providers/git/src/main/scala/restui/providers/git/vcs/VCS.scala
@@ -1,29 +1,24 @@
 package restui.providers.git.vcs
 
 import scala.concurrent.ExecutionContext
-import scala.concurrent.duration._
 
 import akka.actor.ActorSystem
 import akka.stream.scaladsl.{Merge, Source => AkkaSource}
 import restui.models.Service
 import restui.providers.git._
 import restui.providers.git.git.Git
-import restui.providers.git.git.data.Repository
 import restui.providers.git.github.{Github, GithubClient}
 import restui.providers.git.settings.{GitSettings, GithubSettings, Settings}
 
 object VCS {
   def source(settings: Settings, requestExecutor: RequestExecutor)(implicit
       actorSystem: ActorSystem,
-      executionContext: ExecutionContext): Source[Service] = {
-    val vcsSources = settings.vcs.map {
-      case settings: GithubSettings =>
-        Github.retrieveRepositoriesRegularly(GithubClient(settings, requestExecutor))
-      case GitSettings(repositories) => Git.source(repositories)
-    }.fold(AkkaSource.empty[Repository]) { (acc, source) =>
+      executionContext: ExecutionContext): Source[Service] =
+    settings.vcs.map {
+      case githubSettings: GithubSettings =>
+        Git.fromSource(settings.cacheDuration, Github(GithubClient(githubSettings, requestExecutor)))
+      case GitSettings(repositories) => Git.fromSettings(settings.cacheDuration, repositories)
+    }.fold(AkkaSource.empty[Service]) { (acc, source) =>
       AkkaSource.combine(acc, source)(Merge(_))
     }
-
-    AkkaSource.tick(0.second, settings.cacheDuration, ()).zipLatest(vcsSources).map(_._2).via(Git.flow)
-  }
 }

--- a/providers/git/src/test/scala/base/TestBase.scala
+++ b/providers/git/src/test/scala/base/TestBase.scala
@@ -6,14 +6,21 @@ import akka.actor.ActorSystem
 import akka.testkit.{ImplicitSender, TestKit}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.AsyncWordSpecLike
+import org.scalatest.wordspec.{AnyWordSpecLike, AsyncWordSpecLike}
 
-abstract class TestBase
+abstract class AsyncTestBase
     extends TestKit(ActorSystem("test"))
     with ImplicitSender
     with AsyncWordSpecLike
     with Matchers
     with BeforeAndAfterAll {
+  implicit val ec: ExecutionContext = system.dispatcher
+
+  override def afterAll: Unit =
+    TestKit.shutdownActorSystem(system)
+}
+
+abstract class TestBase extends TestKit(ActorSystem("test")) with ImplicitSender with AnyWordSpecLike with Matchers with BeforeAndAfterAll {
   implicit val ec: ExecutionContext = system.dispatcher
 
   override def afterAll: Unit =

--- a/providers/git/src/test/scala/restui/providers/git/git/GitSpec.scala
+++ b/providers/git/src/test/scala/restui/providers/git/git/GitSpec.scala
@@ -82,14 +82,14 @@ class GitSpec extends TestBase with Inside {
           val probe = TestProbe()
           Git.fromSource(duration, Source.single(repo)).to(Sink.actorRef(probe.ref, "completed", _ => ())).run()
 
-          fixture.commit("test", "test2")
-          val resultTest = probe.expectMsgType[Service]
-          inside(resultTest) {
+          inside(probe.expectMsgType[Service]) {
             case Service(_, _, file, _) =>
               file shouldBe "test"
           }
-          val resultTest2 = probe.expectMsgType[Service]
-          inside(resultTest2) {
+
+          fixture.commit("test", "test2")
+
+          inside(probe.expectMsgType[Service]) {
             case Service(_, _, file, _) =>
               file shouldBe "test2"
           }

--- a/providers/git/src/test/scala/restui/providers/git/github/GithubClientSpec.scala
+++ b/providers/git/src/test/scala/restui/providers/git/github/GithubClientSpec.scala
@@ -4,12 +4,12 @@ import scala.concurrent.Future
 
 import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpResponse}
 import akka.stream.scaladsl.Sink
-import base.TestBase
+import base.AsyncTestBase
 import io.circe.syntax._
 import restui.providers.git.github.data.{Error, Node, Repository}
 import restui.providers.git.settings.GithubSettings
 
-class GithubClientSpec extends TestBase {
+class GithubClientSpec extends AsyncTestBase {
   private val github = GithubSettings("MyAwesomeUser", "MyAwesomeUser")
   private val nodes  = Seq(Node("MyAwesomeUser/MyAwesomeRepo", "https://github.com/MyAwesomeUser/MyAwesomeRepo", "master"))
 

--- a/providers/git/src/test/scala/restui/providers/git/github/GithubSpec.scala
+++ b/providers/git/src/test/scala/restui/providers/git/github/GithubSpec.scala
@@ -30,11 +30,11 @@ class GithubSpec extends TestBase with Inside with Inspectors {
 
     val probe = TestProbe()
 
-    Github.retrieveRepositoriesRegularly(client).to(Sink.actorRef(probe.ref, "completed", _ => ())).run()
+    Github(client).to(Sink.actorRef(probe.ref, "completed", _ => ())).run()
     val results = mutable.ListBuffer.empty[GitRepository]
     results += probe.expectMsgType[GitRepository](1.second)
     probe.expectNoMessage(200.millis)
-    results += probe.expectMsgType[GitRepository](1.second)
+    probe.expectNoMessage(1.second)
 
     forAll(results) { result =>
       inside(result) {


### PR DESCRIPTION

- Cache the git repositories
- Only get new repositories from github

✅ Closes #45